### PR TITLE
Change P2P voicemenu spam delay to 4 seconds

### DIFF
--- a/Amalgam/src/Features/Misc/Misc.cpp
+++ b/Amalgam/src/Features/Misc/Misc.cpp
@@ -832,7 +832,7 @@ void CMisc::VoiceCommandSpam(CTFPlayer* pLocal)
 	else
 	{
 		static float flLastVoiceTime = 0.0f;
-		if (flCurrentTime - flLastVoiceTime < 6.5f)
+		if (flCurrentTime - flLastVoiceTime < 4.0f)
 			return;
 			
 		flLastVoiceTime = flCurrentTime;


### PR DESCRIPTION
This is what it was in Cathook: https://github.com/MistakesMultiplied/cathook/blob/6678c17f73417c83ec57c9ae070be400da06a11e/src/hacks/Spam.cpp#L269